### PR TITLE
Propagate http header callback from websocket back to client.

### DIFF
--- a/Source/SocketIO/Client/SocketIOClientSpec.swift
+++ b/Source/SocketIO/Client/SocketIOClientSpec.swift
@@ -334,4 +334,15 @@ public enum SocketClientEvent : String {
     /// }
     /// ```
     case statusChange
+
+    /// Emitted when when upgrading the http connection to a websocket connection.
+    ///
+    /// Usage:
+    ///
+    /// ```swift
+    /// socket.on(clientEvent: .httpResponseHeaders) {data, ack in
+    ///     // Some header logic
+    /// }
+    /// ```
+    case httpResponseHeaders
 }

--- a/Source/SocketIO/Engine/SocketEngine.swift
+++ b/Source/SocketIO/Engine/SocketEngine.swift
@@ -312,6 +312,12 @@ open class SocketEngine : NSObject, URLSessionDelegate, SocketEnginePollable, So
 
             this.parseEngineMessage(message)
         }
+        
+        ws?.onHttpResponseHeaders = {[weak self] headers in
+            guard let this = self else { return }
+
+            this.client?.engineDidReceiveHttpHeaders(headers: headers)
+        }
 
         ws?.connect()
     }

--- a/Source/SocketIO/Engine/SocketEngineClient.swift
+++ b/Source/SocketIO/Engine/SocketEngineClient.swift
@@ -59,4 +59,9 @@ import Foundation
     ///
     /// - parameter data: The data the engine received.
     func parseEngineBinaryData(_ data: Data)
+
+    /// Called when upgrading the http to websocket.
+    ///
+    /// - parameter headers: The http headers.
+    func engineDidReceiveHttpHeaders(headers: [String: String])
 }

--- a/Source/SocketIO/Engine/SocketEngineClient.swift
+++ b/Source/SocketIO/Engine/SocketEngineClient.swift
@@ -60,7 +60,7 @@ import Foundation
     /// - parameter data: The data the engine received.
     func parseEngineBinaryData(_ data: Data)
 
-    /// Called when upgrading the http to websocket.
+    /// Called when when upgrading the http connection to a websocket connection.
     ///
     /// - parameter headers: The http headers.
     func engineDidReceiveHttpHeaders(headers: [String: String])

--- a/Source/SocketIO/Manager/SocketManager.swift
+++ b/Source/SocketIO/Manager/SocketManager.swift
@@ -375,6 +375,19 @@ open class SocketManager : NSObject, SocketManagerSpec, SocketParsable, SocketDa
         emitAll(clientEvent: .ping, data: [])
     }
 
+    /// Called when upgrading the http to websocket.
+    ///
+    /// - parameter headers: The http headers.
+    open func engineDidReceiveHttpHeaders(headers: [String: String]) {
+        handleQueue.async {
+            self._engineDidReceiveHttpHeaders(headers: headers)
+        }
+    }
+
+    private func _engineDidReceiveHttpHeaders(headers: [String: String]) {
+        emitAll(clientEvent: .httpResponseHeaders, data: [headers])
+    }
+
     private func forAll(do: (SocketIOClient) throws -> ()) rethrows {
         for (_, socket) in nsps {
             try `do`(socket)

--- a/Source/SocketIO/Manager/SocketManager.swift
+++ b/Source/SocketIO/Manager/SocketManager.swift
@@ -375,7 +375,7 @@ open class SocketManager : NSObject, SocketManagerSpec, SocketParsable, SocketDa
         emitAll(clientEvent: .ping, data: [])
     }
 
-    /// Called when upgrading the http to websocket.
+    /// Called when when upgrading the http connection to a websocket connection.
     ///
     /// - parameter headers: The http headers.
     open func engineDidReceiveHttpHeaders(headers: [String: String]) {


### PR DESCRIPTION
On Socket.IO Android we already have this callback, so backport it to iOS.